### PR TITLE
credentials for services migrated to iam

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,25 @@ module.exports.getCredentials = function(name, plan, iname) {
   if (process.env.VCAP_SERVICES) {
     var services = JSON.parse(process.env.VCAP_SERVICES);
     for (var service_name in services) {
+      if (service_name === 'ibmcloud-link') {
+      }
       if (service_name.indexOf(name) === 0) {
         for (var i = services[service_name].length - 1; i >= 0; i--) {
           var instance = services[service_name][i];
           if ((!plan || plan === instance.plan) && (!iname || iname === instance.name))
             return instance.credentials || {};
+        }
+      }
+    }
+    // Check if credentials weren't found because the service was migrated to IAM
+    for (var service_name in services) {
+      for (var i = services[service_name].length - 1; i >= 0; i--) {
+        var instance = services[service_name][i];
+        var usingResourceName = instance.credentials && instance.credentials.resource_name;
+        if ((usingResourceName && instance.credentials.resource_name === name) && 
+          (!iname || iname === instance.name)
+        ) {
+          return instance.credentials || {};
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ module.exports.getCredentials = function(name, plan, iname) {
   if (process.env.VCAP_SERVICES) {
     var services = JSON.parse(process.env.VCAP_SERVICES);
     for (var service_name in services) {
-      if (service_name === 'ibmcloud-link') {
-      }
       if (service_name.indexOf(name) === 0) {
         for (var i = services[service_name].length - 1; i >= 0; i--) {
           var instance = services[service_name][i];

--- a/test/test.parse.js
+++ b/test/test.parse.js
@@ -150,3 +150,46 @@ describe('vcap_services', function() {
   });
 
 });
+
+describe('cf to iam migration', function() {
+  var ORIGINAL_VALUE = null;
+  var credentials = {
+    apikey: '10101010101',
+    iam_apikey_description: 'Auto generated apikey during resource-bind...',
+    iam_apikey_name: 'auto-generated-apikey-000-1111',
+    iam_role_crn: 'crn:v1:bluemix:public:iam::::',
+    iam_serviceid_crn: 'crn:v1:staging:public:iam-identity::000-111',
+    resource_name: 'conversation',
+    url: 'https://gateway-s.watsonplatform.net/assistant/api'
+  };
+
+  before(function() {
+    ORIGINAL_VALUE = process.env.VCAP_SERVICES;
+    process.env.VCAP_SERVICES = JSON.stringify({
+      'ibmcloud-link': [
+        {
+          credentials: credentials,
+          label: 'ibmcloud-link',
+          name: 'Watson-Assistant-23',
+          plan: 'ibmcloud-link-alias',
+          provider: null,
+          syslog_drain_url: null,
+          tags: ['ibmcloud-alias'],
+          volume_mounts: []
+        }
+      ]
+    });
+  });
+
+  after(function() {
+    // return the original value to VCAP_SERVICES
+    process.env.VCAP_SERVICES = ORIGINAL_VALUE;
+  });
+
+  it('should find the credentials using the old service name', function() {
+    assert.deepEqual(
+      credentials,
+      vcapServices.getCredentials('conversation', null, null)
+    );
+  });
+});


### PR DESCRIPTION
@germanattanasio I spoke to Taj the other day about this issue. I just took a quick pass at it while I had a free minute. We may not be able to rely on the `resource_name` in `credentials` so this may not be ideal, but it seemed to be that was the best way to support the migration. Let me know what you think.