### PR TITLE
Filter service instances by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ var credentials = vcapServices.getCredentials('natural_language_classifier', 'st
 console.log(credentials);
 ```
 
+### Getting credentials for a specific tag
+Get credentials that match a specific service tag.
+```sh
+var vcapServices = require('vcap_services');
+var credentials = vcapServices.getCredentials('object_storage', null, null, 'eu');
+console.log(credentials);
+```
+
 ## Tests
 Running all the tests:
 ```sh

--- a/index.js
+++ b/index.js
@@ -2,27 +2,28 @@
 
 /**
  * if VCAP_SERVICES exists or the instance name exists in the
- * environemnt, then it returns the credentials
+ * environment, then it returns the credentials
  * for the last service that starts with 'name' or {} otherwise
  * If plan is specified it will return the credentials for
  * the service instance that match that plan or {} otherwise
  * @param  String name, service name
  * @param  String plan, service plan
  * @param  String iname, instance name
+ * @param  String tag, tag
  * @return {Object} the service credentials or {} if
  * name is not found in VCAP_SERVICES or instance name
  * is set as an environmental variable. Env var must be
  * upper case.
  */
 
-const getCredentials = function(name, plan, iname) {
+const getCredentials = function(name, plan, iname, tag) {
   if (process.env.VCAP_SERVICES) {
     var services = JSON.parse(process.env.VCAP_SERVICES);
     for (var service_name in services) {
       if (service_name.indexOf(name) === 0) {
         for (var i = services[service_name].length - 1; i >= 0; i--) {
           var instance = services[service_name][i];
-          if ((!plan || plan === instance.plan) && (!iname || iname === instance.name))
+          if ((!plan || plan === instance.plan) && (!iname || iname === instance.name) && (!tag || (instance.tags || []).includes(tag)))
             return instance.credentials || {};
         }
       }

--- a/test/test.parse.js
+++ b/test/test.parse.js
@@ -65,6 +65,17 @@ describe('vcap_services', function() {
         name: 'NLC 2',
         plan: 'standard',
         credentials: credentials
+      }],
+      object_storage: [{
+        name: 'OS 1',
+        plan: 'standard',
+        credentials: credentials,
+        tags: ['eu']
+      },{
+        name: 'OS 2',
+        plan: 'standard',
+        credentials: credentials,
+        tags: ['us']
       }]
     });
   });
@@ -106,6 +117,13 @@ describe('vcap_services', function() {
     assert.deepEqual(credentials, vcapServices.getCredentials('natural_language_classifier','standard','NLC 1'));
     assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 1'));
     assert.deepEqual({}, vcapServices.getCredentials('natural_language_classifier','foo','NLC 3'));
+  });
+
+  it('should return the last available credentials that match a tag', function() {
+    assert.deepEqual(credentials, vcapServices.getCredentials('object_storage',null,null,'eu'));
+    assert.deepEqual({}, vcapServices.getCredentials('object_storage',null,null,'sa'));
+    assert.deepEqual({}, vcapServices.getCredentials('object_storage','foo',null,'eu'));
+    assert.deepEqual({}, vcapServices.getCredentials('object_storage','foo',null,'sa'));
   });
 
   it('should return {} when service plan not found', function() {


### PR DESCRIPTION
This adds an additional parameter to `getCredentials` permitting specification of a tag by which to filter the service instance.